### PR TITLE
attack/gain support

### DIFF
--- a/src/notePlayer.js
+++ b/src/notePlayer.js
@@ -184,7 +184,12 @@ notePlayer.prototype.play = function(callback) {
     var oscillator = this.audioContext.createOscillator()
     oscillator.frequency.value = this.frequency
     var gainNode = this.audioContext.createGain()
-    gainNode.gain.value = this.volume
+    if (this.attack) {
+      gainNode.gain.linearRampToValueAtTime(this.volume, this.audioContext.currentTime + this.attack);
+      gainNode.gain.setTargetAtTime(0, this.audioContext.currentTime + this.attack, this.release || this.attack);
+    } else {
+      gainNode.gain.value = this.volume
+    }
 
     //Connections
     oscillator.connect(gainNode)


### PR DESCRIPTION
Lets you specify an attack/release duration which gives the note a _twang_ effect, imitating a much more realistic instrument.

Checks for a `this.attack` property, if found, increases the gain linearly using `linearRampToValueAtTime`. Then uses `this.release` (if found, or re-uses `this.attack`) to set gain back to 0.

If `this.attack` is not found, falls back to old behavior.

Usage:

```
var note = notePlayer.buildFromName('C4');
note.attack = 0.1;
note.release = 0.5;
note.play()
```
